### PR TITLE
Feature: Allow Mason retain DOM event handlers on filler blocks with user specified property

### DIFF
--- a/mason.js
+++ b/mason.js
@@ -24,7 +24,8 @@
 			promoted: [],
 			filler: {
 				itemSelector: options.itemSelector,
-				filler_class: 'mason_filler'
+				filler_class: 'mason_filler',
+				keepDataAndEvents: false
 			},
 			randomSizes:false,
 			randomFillers:false,
@@ -228,7 +229,7 @@
 									ran =  fillerNum -1;
 								}
 								
-								filler = $(settings.filler.itemSelector).eq(ran).clone();
+								filler = $(settings.filler.itemSelector).eq(ran).clone(settings.filler.keepDataAndEvents);
 
 								filler.addClass(settings.filler.filler_class);
 								filler.css({

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,8 @@ $("#container").mason({
 	],
 	filler: {
 		itemSelector: '.fillerBox',
-		filler_class: 'custom_filler'
+		filler_class: 'custom_filler',
+		keepDataAndEvents: false
 	},
 	layout: 'fluid',
 	gutter: 10
@@ -86,6 +87,7 @@ $("#container").mason({
 		<ul>
 			<li>itemSelector: This describes the elements to be used to fill in blank spaces. This will default to the original itemSelector if there is nothing</li>
 			<li>filler_class: This is a class given to filler elements within the grid, used for cleaning up if a grid set to fluid</li>
+			<li>keepDataAndEvents: Mason creates a clone of the filler elements before adding them to the grid, this boolean (true/false) property tells  Mason to retain the events and data that have already been bound to the filler elements</li>
 		</ul>
 	</li>
 	<li><strong>Layout</strong>


### PR DESCRIPTION
Hi @DrewDahlman Added a property to the filler options, that allows jQuery to retain event handlers  with the filler elements. As of jQuery 1.4, element data will be copied as well so the "keepData" part of the property name is just for clarity and keeping with the jQuery docs. http://api.jquery.com/clone/ 
This will resolve issue: https://github.com/DrewDahlman/Mason/issues/38.
Cheers.