### PR TITLE
rounding errors cause empty white space

### DIFF
--- a/src/mason.coffee
+++ b/src/mason.coffee
@@ -136,12 +136,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 				#
 				#	Set the element block height
 				#
-				elements.block.height = Math.round(parseFloat(($self.width() / columnSize()) / settings.ratio)).toFixed(2)
+				elements.block.height = Math.floor(parseFloat(($self.width() / columnSize()) / settings.ratio)).toFixed(2)
 
 				#
 				#	Set the element block width
 				#
-				elements.block.width = Math.round(parseFloat(($self.width() / columnSize()))).toFixed(2)
+				elements.block.width = Math.floor(parseFloat(($self.width() / columnSize()))).toFixed(2)
 
 				#
 				#	Set Start Width


### PR DESCRIPTION
If the total available size is not dividable between the desired amount of columns, you possibly get empty space.
Example: 
Available width: 20px
Desired cols: 3.

Each col width: 6.66px, current code rounds it to 7px.
7px x 3 cols cuases the last block to jump to a new line.
Flooring the width results in 3 x 6px cols.

Ideally, it should create blocks 6, 6 & 7px wide, however, my fix is easy and results in only 2 empty pixels on the right and 3 cols as desired.