### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This is not Masonry, or Isotope or Gridalicious. Mason fills in those ugly gaps,
 
 `2.0.2`
 
-##USE
+## USE
 
 **Basic CSS**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
